### PR TITLE
Update rpc gnosis

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -34,7 +34,7 @@ module.exports = {
   },
 
   rpcEndpoints: {
-    100: 'https://dai.poa.network',
+    100: 'https://rpc.gnosischain.com',
     137: 'https://matic-mainnet-full-rpc.bwarelabs.com'
   },
 


### PR DESCRIPTION
The [dai.poa.network](https://dai.poa.network) is not more availble, replaced for https://rpc.gnosischain.com